### PR TITLE
initial 0.13.10

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/aws-c-cal-feedstock/pr1/ea61a89
-  - https://staging.continuum.io/prefect/fs/s2n-feedstock/pr1/ade4da2
- 

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,4 @@
+channels:
+  - https://staging.continuum.io/prefect/fs/aws-c-cal-feedstock/pr1/ea61a89
+  - https://staging.continuum.io/prefect/fs/s2n-feedstock/pr1/ade4da2
+ 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,6 +12,8 @@ build:
   number: 0
   run_exports:
     - {{ pin_subpackage("aws-c-io", max_pin="x.x.x") }}
+  missing_dso_whitelist:  # [s390x]
+    - '$RPATH/ld64.so.1'  # [s390x]
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,6 +38,14 @@ about:
   license_family: Apache
   license_file: LICENSE
   summary: This is a module for the AWS SDK for C. It handles all IO and TLS work for application protocols.
+  description: |
+    This is an event driven framework for implementing application protocols. It is built on top of cross-platform 
+    abstractions that allow you as a developer to think only about the state machine and API for your protocols.
+    A typical use-case would be to write something like Http on top of asynchronous-io with TLS already baked in. 
+    All of the platform and security concerns are already handled for you.
+  dev_url: https://github.com/awslabs/aws-c-io
+  doc_url: https://github.com/awslabs/aws-c-io
+
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.14.2" %}
+{% set version = "0.13.10" %}
 
 package:
   name: aws-c-io
@@ -6,10 +6,10 @@ package:
 
 source:
   url: https://github.com/awslabs/aws-c-io/archive/v{{ version }}.tar.gz
-  sha256: 791ca7168aba93885e69343612fd13356c7fe11dff04f6b774136d8d4aed6b6a
+  sha256: 4e7caa335ece916c00f4c9896e7413bb6ed52abc77e2c3dda3ffe5bcf3fc8655
 
 build:
-  number: 1
+  number: 0
   run_exports:
     - {{ pin_subpackage("aws-c-io", max_pin="x.x.x") }}
 
@@ -17,11 +17,11 @@ requirements:
   build:
     - cmake !=3.19.0,!=3.19.1
     - {{ compiler('c') }}
-    - ninja
+    - ninja-base
   host:
-    - aws-c-common
-    - aws-c-cal
-    - s2n  # [linux]
+    - aws-c-common 0.8.5
+    - aws-c-cal 0.5.20
+    - s2n 1.3.27 # [linux]
 
 test:
   commands:


### PR DESCRIPTION
aws-c-io 0.13.10

Destination channel: defaults

Links
[ticket_number](https://anaconda.atlassian.net/browse/PKG-3944)
[Upstream repository](https://github.com/awslabs/aws-c-io/tree/v0.13.10)
dependency for aws-c-event-stream 0.2.15 -> aws-sdk-cpp 1.10.55 -> arrow-cpp 14.0.1 -> pyarrow 14.0.1 which would address CVE
