### PR TITLE
aws-c-io 0.17.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - https://staging.continuum.io/prefect/fs/aws-c-cal-feedstock/pr2/071091c

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,3 @@
 channels:
   - https://staging.continuum.io/prefect/fs/aws-c-cal-feedstock/pr2/071091c
+  - https://staging.continuum.io/prefect/fs/s2n-feedstock/pr2/9f12ab9

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/aws-c-cal-feedstock/pr2/071091c
-  - https://staging.continuum.io/prefect/fs/s2n-feedstock/pr2/9f12ab9

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,7 @@ requirements:
   host:
     - aws-c-common 0.11.1
     - aws-c-cal 0.8.5
-    - s2n 1.3.27 # [linux]
+    - s2n 1.5.14 # [linux]
 
 test:
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.13.10" %}
+{% set version = "0.17.0" %}
 
 package:
   name: aws-c-io
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/awslabs/aws-c-io/archive/v{{ version }}.tar.gz
-  sha256: 4e7caa335ece916c00f4c9896e7413bb6ed52abc77e2c3dda3ffe5bcf3fc8655
+  sha256: edf8dbd19704685f7400c6fc3fcb875ab858b1e55382c7ec933efddff28b2332
 
 build:
   number: 0
@@ -39,9 +39,9 @@ about:
   license_file: LICENSE
   summary: This is a module for the AWS SDK for C. It handles all IO and TLS work for application protocols.
   description: |
-    This is an event driven framework for implementing application protocols. It is built on top of cross-platform 
+    This is an event driven framework for implementing application protocols. It is built on top of cross-platform
     abstractions that allow you as a developer to think only about the state machine and API for your protocols.
-    A typical use-case would be to write something like Http on top of asynchronous-io with TLS already baked in. 
+    A typical use-case would be to write something like Http on top of asynchronous-io with TLS already baked in.
     All of the platform and security concerns are already handled for you.
   dev_url: https://github.com/awslabs/aws-c-io
   doc_url: https://github.com/awslabs/aws-c-io

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,8 +21,8 @@ requirements:
     - {{ compiler('c') }}
     - ninja-base
   host:
-    - aws-c-common 0.8.5
-    - aws-c-cal 0.5.20
+    - aws-c-common 0.11.1
+    - aws-c-cal 0.8.5
     - s2n 1.3.27 # [linux]
 
 test:


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-7286](https://anaconda.atlassian.net/browse/PKG-7286)
- [Upstream repository](https://github.com/awslabs/aws-c-io/tree/v0.17.0)


### Explanation of changes:

- Update version
- Update dependencies


[PKG-7286]: https://anaconda.atlassian.net/browse/PKG-7286?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ